### PR TITLE
Add SortedTree

### DIFF
--- a/src/SortedTree.ts
+++ b/src/SortedTree.ts
@@ -1,0 +1,43 @@
+import { Tree } from "./Tree";
+
+export abstract class SortedTree extends Tree {
+	/**
+	 * If this.compare(that) < 0,  then this < that
+	 * If this.compare(that) == 0, then this == that
+	 * If this.compare(that) > 0,  then this > that
+	 */
+	abstract compare(that: this): number;
+
+	appendChild(newTree: this): this {
+		this.insertIn(this.children, newTree);
+		return newTree;
+	}
+
+	// Inserts newTree somewhere after reference, though not necessarily right after.
+	insertAfter(reference: this | undefined, newTree: this): this | undefined {
+		if (!reference) return this.appendChild(newTree);
+		if (reference.compare(newTree) > 0) throw Error("Cannot insert after larger element");
+		if (this.hasChild(reference)) {
+			return this.insertIn([reference, ...reference.nextSiblings()], newTree);
+		}
+	}
+
+	// Inserts newTree somewhere before reference, though not necessarily right before.
+	insertBefore(reference: this | undefined, newTree: this): this | undefined {
+		if (!reference) return this.appendChild(newTree);
+		if (reference.compare(newTree) < 0) throw Error("Cannot insert before smaller element");
+		if (this.hasChild(reference)) {
+			return this.insertIn([...reference.previousSiblings(), reference], newTree);
+		}
+	}
+
+	protected insertIn(list: Iterable<this>, newTree: this): this {
+		const firstLarger = this.children.find(child => child.compare(newTree) >= 0);
+		if (firstLarger) {
+			super.insertBefore(firstLarger, newTree);
+		} else {
+			super.appendChild(newTree);
+		}
+		return newTree;
+	}
+}

--- a/src/Tree.ts
+++ b/src/Tree.ts
@@ -68,8 +68,7 @@ export class Tree {
 	}
 
 	push(...newTrees: this[]): number {
-		newTrees.forEach((tree: this) => tree.reparent(this));
-		this._children.push(...newTrees);
+		newTrees.forEach(tree => this.appendChild(tree));
 		return this._children.length;
 	}
 
@@ -79,7 +78,7 @@ export class Tree {
 
 	insertBefore(reference: this | undefined, newTree: this): this | undefined {
 		if (!reference) return this.appendChild(newTree);
-		if (this._children.includes(reference)) {
+		if (this.hasChild(reference)) {
 			newTree.reparent(this);
 			this._children.splice(this._children.indexOf(reference), 0, newTree);
 			return newTree;
@@ -117,6 +116,10 @@ export class Tree {
 		if (this.parent === that) return true;
 		if (this.parent) return this.parent.isChildOf(that);
 		return false;
+	}
+
+	hasChild(reference: this): boolean {
+		return this._children.includes(reference);
 	}
 
 	*childrenAfter(reference: this): Iterable<this> {

--- a/test/SortedTreeTest.ts
+++ b/test/SortedTreeTest.ts
@@ -1,0 +1,102 @@
+import * as assert from "assert";
+import { SortedTree } from "../src/SortedTree";
+
+class TestTree extends SortedTree {
+	constructor(public value: number) {
+		super();
+	}
+
+	compare(that: this): number {
+		return this.value - that.value;
+	}
+}
+
+describe("SortedTree", () => {
+	/**
+	 *  0
+	 *  +--1
+	 *  |  +--2
+	 *  |     +--3
+	 *  |        +--4
+	 *  +--5
+	 *  +--6
+	 *
+	 *  7
+	 *  +--8
+	 *  +--9
+	 */
+	function exampleTrees(): TestTree[] {
+		const trees: TestTree[] = Array(10);
+		trees[9] = new TestTree(9);
+		trees[8] = new TestTree(8);
+		trees[7] = new TestTree(7);
+		trees[7].push(trees[8], trees[9]);
+		trees[6] = new TestTree(6);
+		trees[5] = new TestTree(5);
+		trees[4] = new TestTree(4);
+		trees[3] = new TestTree(3);
+		trees[3].push(trees[4]);
+		trees[2] = new TestTree(2);
+		trees[2].push(trees[3]);
+		trees[1] = new TestTree(1);
+		trees[1].push(trees[2]);
+		trees[0] = new TestTree(0);
+		trees[0].push(trees[1], trees[5], trees[6]);
+		return trees;
+	}
+
+	function isSorted(tree: TestTree): boolean {
+		const childrenSorted = tree.children.every(
+			child => (child.nextSibling ? child.compare(child.nextSibling) <= 0 : true)
+		);
+		return childrenSorted && tree.children.every(isSorted);
+	}
+
+	it("is sorted when empty", () => {
+		assert(isSorted(new TestTree(0)));
+	});
+
+	describe("#push", () => {
+		it("preserves sort order", () => {
+			// exampleTrees uses push internally, so we're relying on that
+			const trees = exampleTrees();
+			assert(isSorted(trees[0]));
+			assert(isSorted(trees[7]));
+		});
+	});
+
+	describe("#appendChild", () => {
+		it("preserves sort order", () => {
+			const tree = exampleTrees()[0];
+			for (let i = -10; i < 10; ++i) {
+				tree.appendChild(new TestTree(i));
+			}
+			assert(isSorted(tree));
+		});
+	});
+
+	describe("#insertBefore", () => {
+		it("preserves sort order", () => {
+			const tree = exampleTrees()[0];
+			for (let i = -10; i < 10; ++i) {
+				tree.insertBefore(undefined, new TestTree(i));
+			}
+			assert(isSorted(tree));
+		});
+
+		it("returns undefined if `reference` node is not a child", () => {
+			const trees = exampleTrees();
+			assert.strictEqual(trees[1].insertAfter(trees[5], trees[7]), undefined);
+		});
+	});
+
+	describe("#insertAfter", () => {
+		it("preserves sort order", () => {
+			const tree = exampleTrees()[0];
+			for (let i = -10; i < 10; ++i) {
+				tree.insertAfter(undefined, new TestTree(i));
+			}
+			assert(isSorted(tree));
+		});
+	});
+});


### PR DESCRIPTION
This allows us to get rid of `sort` in the [ts-tree-ui `Model`](https://github.com/mbovel/ts-tree-ui/blob/v0.1.15/src/Model.ts#L172-L177). 

This `sort` function depends on the value `V`, and the ts-tree refactor of v0.2.0 removes the notion of having a value `V` tied to a tree. Instead, you can bind the values you'd like to the tree by extending `Tree`. This also means that there's no longer any convenient way of sorting trees from their value `V` in ts-tree-ui without forcing an upper type bound of `ValueTree<V> extends Tree` or something like that.

Instead, this PR refactors the sorting to the Tree itself, and hopefully allows for the the ts-tree-ui Model to be sort-agnostic. There's no need to provide a `sort?` parameter to the ts-tree-ui Model constructor; now, whether to sort simply depends on whether the tree is a `SortedTree` or a regular `Tree`.

With this change, `Tree.push` relies on `Tree.appendChild`, which is DRYer, and allows me to extend more easily.

**Edit**: there may actually be better ways to do this. Let's discuss it irl